### PR TITLE
Add support for require.resolve() in Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "6.1.1",
   "description": "Grid based off of CSS3 flexbox specification",
   "style": "dist/flexboxgrid.css",
+  "main": "dist/flexboxgrid.css",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
Because flexboxgrid's `package.json` didn't have a `main` directive, Node's `require.resolve()` function can't resolve it. This PR points `main` to the unminified CSS file. This is useful for build scripts, for example

```js
gulp.task('css', function() {
    var flexboxGrid = require.resolve('flexboxgrid')
    fs.createReadStream(flexboxGrid)
        .pipe(source('flexboxgrid.css'))
        .pipe(gulp.dest('css/flexboxgrid.css'))
})
```