### PR TITLE
Remove redundant CSS

### DIFF
--- a/src/css/flexboxgrid.css
+++ b/src/css/flexboxgrid.css
@@ -74,10 +74,8 @@
 .col-xs-offset-12 {
   box-sizing: border-box;
   display: flex;
-  flex: 0 1 auto;
+  flex: 0 0 auto;
   flex-direction: column;
-  flex-grow: 0;
-  flex-shrink: 0;
   padding-right: var( --half-gutter-width, 0.5rem );
   padding-left: var( --half-gutter-width, 0.5rem );
 }
@@ -267,10 +265,8 @@
   .col-sm-offset-12 {
     box-sizing: border-box;
     display: flex;
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     flex-direction: column;
-    flex-grow: 0;
-    flex-shrink: 0;
     padding-right: var( --half-gutter-width, 0.5rem );
     padding-left: var( --half-gutter-width, 0.5rem );
   }
@@ -461,10 +457,8 @@
   .col-md-offset-12 {
     box-sizing: border-box;
     display: flex;
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     flex-direction: column;
-    flex-grow: 0;
-    flex-shrink: 0;
     padding-right: var( --half-gutter-width, 0.5rem );
     padding-left: var( --half-gutter-width, 0.5rem );
   }
@@ -655,10 +649,8 @@
   .col-lg-offset-12 {
     box-sizing: border-box;
     display: flex;
-    flex: 0 1 auto;
+    flex: 0 0 auto;
     flex-direction: column;
-    flex-grow: 0;
-    flex-shrink: 0;
     padding-right: var( --half-gutter-width, 0.5rem );
     padding-left: var( --half-gutter-width, 0.5rem );
   }


### PR DESCRIPTION
The flex-grow and flex-shrink property are already being set with the flex property.