### PR TITLE
Deleted unnecessary styles from offset columns

### DIFF
--- a/css/flexboxgrid.css
+++ b/css/flexboxgrid.css
@@ -55,19 +55,7 @@
 .col-xs-9,
 .col-xs-10,
 .col-xs-11,
-.col-xs-12,
-.col-xs-offset-1,
-.col-xs-offset-2,
-.col-xs-offset-3,
-.col-xs-offset-4,
-.col-xs-offset-5,
-.col-xs-offset-6,
-.col-xs-offset-7,
-.col-xs-offset-8,
-.col-xs-offset-9,
-.col-xs-offset-10,
-.col-xs-offset-11,
-.col-xs-offset-12 {
+.col-xs-12 {
   box-sizing: border-box;
   flex: 0 0 auto;
   padding-right: var( --half-gutter-width, 0.5rem );
@@ -244,19 +232,7 @@
   .col-sm-9,
   .col-sm-10,
   .col-sm-11,
-  .col-sm-12,
-  .col-sm-offset-1,
-  .col-sm-offset-2,
-  .col-sm-offset-3,
-  .col-sm-offset-4,
-  .col-sm-offset-5,
-  .col-sm-offset-6,
-  .col-sm-offset-7,
-  .col-sm-offset-8,
-  .col-sm-offset-9,
-  .col-sm-offset-10,
-  .col-sm-offset-11,
-  .col-sm-offset-12 {
+  .col-sm-12 {
     box-sizing: border-box;
     flex: 0 0 auto;
     padding-right: var( --half-gutter-width, 0.5rem );
@@ -434,19 +410,7 @@
   .col-md-9,
   .col-md-10,
   .col-md-11,
-  .col-md-12,
-  .col-md-offset-1,
-  .col-md-offset-2,
-  .col-md-offset-3,
-  .col-md-offset-4,
-  .col-md-offset-5,
-  .col-md-offset-6,
-  .col-md-offset-7,
-  .col-md-offset-8,
-  .col-md-offset-9,
-  .col-md-offset-10,
-  .col-md-offset-11,
-  .col-md-offset-12 {
+  .col-md-12 {
     box-sizing: border-box;
     flex: 0 0 auto;
     padding-right: var( --half-gutter-width, 0.5rem );
@@ -624,19 +588,7 @@
   .col-lg-9,
   .col-lg-10,
   .col-lg-11,
-  .col-lg-12,
-  .col-lg-offset-1,
-  .col-lg-offset-2,
-  .col-lg-offset-3,
-  .col-lg-offset-4,
-  .col-lg-offset-5,
-  .col-lg-offset-6,
-  .col-lg-offset-7,
-  .col-lg-offset-8,
-  .col-lg-offset-9,
-  .col-lg-offset-10,
-  .col-lg-offset-11,
-  .col-lg-offset-12 {
+  .col-lg-12 {
     box-sizing: border-box;
     flex: 0 0 auto;
     padding-right: var( --half-gutter-width, 0.5rem );


### PR DESCRIPTION
Hello

Thanks for great solution for flex grid. I currently start using it my project and found small issue:
offset columns have a basic column styles, but they are not used without the primary column class, so this additional styles are unnecessary and I do a small delete improvement.