### PR TITLE
Add margins to .container class to match bootstrap behavior

### DIFF
--- a/src/css/flexboxgrid.css
+++ b/src/css/flexboxgrid.css
@@ -20,9 +20,12 @@
 @custom-media --md-viewport only screen and (min-width: 64em);
 @custom-media --lg-viewport only screen and (min-width: 75em);
 
-.container-fluid {
+.container-fluid, .container {
   margin-right: auto;
   margin-left: auto;
+}
+
+.container-fluid {
   padding-right: var(--outer-margin, 2rem);
   padding-left: var(--outer-margin, 2rem);
 }


### PR DESCRIPTION
From #24 and #26 it sounds like `.container` should match the api/expected behavior of bootstrap's grid system, which includes auto'd [margins](https://github.com/twbs/bootstrap/blob/3487898a6af8c1d5b12f7b040d30e71b19e34923/less/mixins/grid.less#L6-L12) on both [`.container`](https://github.com/twbs/bootstrap/blob/3487898a6af8c1d5b12f7b040d30e71b19e34923/less/grid.less#L10-L32) and `.container-fluid`

Thoughts, @kristoferjoseph?