### PR TITLE
Prefer widths under 100%

### DIFF
--- a/src/css/flexboxgrid.css
+++ b/src/css/flexboxgrid.css
@@ -91,8 +91,8 @@
 }
 
 .col-xs-2 {
-  flex-basis: 16.667%;
-  max-width: 16.667%;
+  flex-basis: 16.666%;
+  max-width: 16.666%;
 }
 
 .col-xs-3 {
@@ -150,7 +150,7 @@
 }
 
 .col-xs-offset-2 {
-  margin-left: 16.667%;
+  margin-left: 16.666%;
 }
 
 .col-xs-offset-3 {
@@ -280,8 +280,8 @@
   }
 
   .col-sm-2 {
-    flex-basis: 16.667%;
-    max-width: 16.667%;
+    flex-basis: 16.666%;
+    max-width: 16.666%;
   }
 
   .col-sm-3 {
@@ -339,7 +339,7 @@
   }
 
   .col-sm-offset-2 {
-    margin-left: 16.667%;
+    margin-left: 16.666%;
   }
 
   .col-sm-offset-3 {
@@ -470,8 +470,8 @@
   }
 
   .col-md-2 {
-    flex-basis: 16.667%;
-    max-width: 16.667%;
+    flex-basis: 16.666%;
+    max-width: 16.666%;
   }
 
   .col-md-3 {
@@ -529,7 +529,7 @@
   }
 
   .col-md-offset-2 {
-    margin-left: 16.667%;
+    margin-left: 16.666%;
   }
 
   .col-md-offset-3 {
@@ -660,8 +660,8 @@
   }
 
   .col-lg-2 {
-    flex-basis: 16.667%;
-    max-width: 16.667%;
+    flex-basis: 16.666%;
+    max-width: 16.666%;
   }
 
   .col-lg-3 {
@@ -719,7 +719,7 @@
   }
 
   .col-lg-offset-2 {
-    margin-left: 16.667%;
+    margin-left: 16.666%;
   }
 
   .col-lg-offset-3 {


### PR DESCRIPTION
Usage of `16.667%` can lead to widths totaling up to greater than 100%, forcing columns to the next row on certain widths:

Example fiddle: http://jsfiddle.net/c9dymmy1/
Example fiddle with this branch: http://jsfiddle.net/0k2jpbdL/1/

Bootstrap gets around this by [rounding differently on left/right padding](https://github.com/twbs/bootstrap/pull/16351) but we're using rems there instead, so we can't do the calculation ahead of time.