### PR TITLE
Fix percentWidth and percentOffset mixins

### DIFF
--- a/sass/flexboxgrid.scss
+++ b/sass/flexboxgrid.scss
@@ -49,12 +49,12 @@ $offset-properties: 'margin-left' !default;
 }
 
 @mixin percentWidth($property, $columns, $count) {
-  $property: ((100% / $columns) * $count);
+  #{$property}: ((100% / $columns) * $count);
 }
 
 @mixin percentOffset($property, $columns, $count) {
   $single-column-width: ((100% / $columns) * 1);
-  $property: $single-column-width * $count;
+  #{$property}: $single-column-width * $count;
 }
 
 @mixin queries($key, $queries) {


### PR DESCRIPTION
On my setup (Building Sass with [node-sass@3.3.2](https://github.com/sass/node-sass/releases/tag/v3.3.2)) the percentWidth and percentOffset mixins return nothing because the `$property` vars aren't interpolated. 
This commit adds [Sass-hashing](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#interpolation_) to get them working.