### PR TITLE
Separate sass generated styles from mixins and variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,12 @@
   "style": "flexboxgrid.css",
   "main": "flexboxgrid.css",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
     "css": "cssnext --no-rem css/flexboxgrid.css > flexboxgrid.css",
+    "build:css": "npm run css && npm run post && npm run min",
     "sass": "node-sass sass/flexboxgrid.scss flexboxgrid.css",
+    "build:sass": "npm run sass && npm run post && npm run min",
     "less": "lessc less/flexboxgrid.less flexboxgrid.css",
+    "build:less": "npm run less && npm run post && npm run min",
     "post": "postcss --use autoprefixer --use css-mqpacker -o flexboxgrid.css flexboxgrid.css",
     "min": "postcss --use csswring -o flexboxgrid.min.css flexboxgrid.css"
   },
@@ -34,6 +36,7 @@
     "csswring": "^3.0.5",
     "less": "^2.5.1",
     "node-sass": "^3.1.2",
-    "postcss-cli": "^1.3.1"
+    "postcss-cli": "^1.3.1",
+    "css-mqpacker": "3.1.0"
   }
 }

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -28,27 +28,28 @@
 
 @mixin columns($selector: $column-selector, $properties: $column-properties, $columns: $column-count, $queries: $queries) {
   @for $i from 0 through $columns {
-    @each $size in $sizes {
+    @each $name, $size in $queries {
       @if ($i == 0) {
-        #{$selector + $block-delimiter + $size} {
+        #{$selector + $block-delimiter + $name} {
           @content;
         }
       } @else {
-        #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
+        #{$selector + $block-delimiter + $name + $modifier-delimiter + $i} {
           @content;
         }
       }
     }
   }
-  @each $size in $sizes {
-    @include queries($size, $queries) {
+
+  @each $name, $size in $queries {
+    @include queries($name, $queries) {
       @for $i from 0 through $columns {
         @if ($i == 0) {
-          #{$selector + $block-delimiter + $size} {
+          #{$selector + $block-delimiter + $name} {
             @include autoWidth();
           }
         } @else {
-          #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
+          #{$selector + $block-delimiter + $name + $modifier-delimiter + $i} {
             @each $prop in $properties {
               @include percentWidth($prop, $columns, $i);
             }
@@ -60,17 +61,18 @@
 }
 
 @mixin offsets($selector: $column-selector, $modifier-selector: $offset-modifier, $properties: $offset-properties, $columns: $column-count, $queries: $queries) {
-  @each $size in $sizes {
+  @each $name, $size in $queries {
     @for $i from 1 through $columns {
-      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
+      #{$selector + $block-delimiter + $name + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
         @content;
       }
     }
   }
-  @each $size in $sizes {
+
+  @each $name, $size in $queries {
     @for $i from 1 through $columns {
-      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
-        @include queries($size, $queries) {
+      #{$selector + $block-delimiter + $name + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
+        @include queries($name, $queries) {
           @each $prop in $properties {
             @include percentOffset($prop, $columns, $i);
           }
@@ -81,9 +83,9 @@
 }
 
 @mixin breakpoints($selector, $queries: $queries) {
-  @each $size in $sizes {
-    #{$selector + $modifier-delimiter + $size} {
-      @include queries($size, $queries) {
+  @each $name, $size in $queries {
+    #{$selector + $modifier-delimiter + $name} {
+      @include queries($name, $queries) {
         @content;
       }
     }

--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -1,0 +1,116 @@
+@import 'variables';
+
+@mixin autoWidth() {
+  flex-grow: 1;
+  flex-basis: 0;
+  max-width: 100%;
+}
+
+@mixin percentWidth($property, $columns, $count) {
+  #{$property}: ((100% / $columns) * $count);
+}
+
+@mixin percentOffset($property, $columns, $count) {
+  $single-column-width: ((100% / $columns) * 1);
+  #{$property}: $single-column-width * $count;
+}
+
+@mixin queries($key, $queries) {
+  $query: map-get($queries, $key);
+  @if ($query == $default-query) {
+    @content;
+  } @else {
+    @media screen and (min-width: $query) {
+      @content;
+    }
+  }
+}
+
+@mixin columns($selector: $column-selector, $properties: $column-properties, $columns: $column-count, $queries: $queries) {
+  @for $i from 0 through $columns {
+    @each $size in $sizes {
+      @if ($i == 0) {
+        #{$selector + $block-delimiter + $size} {
+          @content;
+        }
+      } @else {
+        #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
+          @content;
+        }
+      }
+    }
+  }
+  @each $size in $sizes {
+    @include queries($size, $queries) {
+      @for $i from 0 through $columns {
+        @if ($i == 0) {
+          #{$selector + $block-delimiter + $size} {
+            @include autoWidth();
+          }
+        } @else {
+          #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
+            @each $prop in $properties {
+              @include percentWidth($prop, $columns, $i);
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+@mixin offsets($selector: $column-selector, $modifier-selector: $offset-modifier, $properties: $offset-properties, $columns: $column-count, $queries: $queries) {
+  @each $size in $sizes {
+    @for $i from 1 through $columns {
+      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
+        @content;
+      }
+    }
+  }
+  @each $size in $sizes {
+    @for $i from 1 through $columns {
+      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
+        @include queries($size, $queries) {
+          @each $prop in $properties {
+            @include percentOffset($prop, $columns, $i);
+          }
+        }
+      }
+    }
+  }
+}
+
+@mixin breakpoints($selector, $queries: $queries) {
+  @each $size in $sizes {
+    #{$selector + $modifier-delimiter + $size} {
+      @include queries($size, $queries) {
+        @content;
+      }
+    }
+  }
+}
+
+@mixin container-fluid() {
+  box-sizing: border-box;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: $outer-margin;
+  padding-left: $outer-margin;
+}
+
+@mixin row() {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  margin-right: $gutter-compensation;
+  margin-left: $gutter-compensation;
+}
+
+@mixin column() {
+  box-sizing: border-box;
+  flex-grow: 0;
+  flex-shrink: 0;
+  padding-right: $half-gutter-width;
+  padding-left: $half-gutter-width;
+}

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -12,14 +12,14 @@ $width-sm: 48 !default;
 $width-md: 62 !default;
 $width-lg: 75 !default;
 
-$viewport-xs: #{$width-xs}em !default;
-$viewport-sm: #{$width-sm}em !default;
-$viewport-md: #{$width-md}em !default;
-$viewport-lg: #{$width-lg}em !default;
+$viewport-xs: $width-xs * 1em !default;
+$viewport-sm: $width-sm * 1em !default;
+$viewport-md: $width-md * 1em !default;
+$viewport-lg: $width-lg * 1em !default;
 
-$container-sm: #{$width-sm}rem + $gutter-width !default;
-$container-md: #{$width-md}rem + $gutter-width !default;
-$container-lg: #{$width-lg}rem + $gutter-width !default;
+$container-sm: $width-sm * 1rem + $gutter-width !default;
+$container-md: $width-md * 1rem + $gutter-width !default;
+$container-lg: $width-lg * 1rem + $gutter-width !default;
 
 $xs: 'xs' !default;
 $sm: 'sm' !default;
@@ -31,8 +31,13 @@ $element-delimiter: '-' !default;
 $modifier-delimiter: '-' !default;
 
 $defaultQuery: $viewport-xs !default;
-$sizes: #{$xs}, #{$sm}, #{$md}, #{$lg} !default;
-$queries: (#{$xs}:#{$viewport-xs}, #{$sm}:#{$viewport-sm}, #{$md}:#{$viewport-md}, #{$lg}:#{$viewport-lg}) !default;
+$sizes: $xs, $sm, $md, $lg !default;
+$queries: (
+  $xs: $viewport-xs,
+  $sm: $viewport-sm,
+  $md: $viewport-md,
+  $lg: $viewport-lg
+) !default;
 
 $column-properties: 'flex-basis', 'max-width' !default;
 $offset-properties: 'margin-left' !default;

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -30,7 +30,7 @@ $block-delimiter: '-' !default;
 $element-delimiter: '-' !default;
 $modifier-delimiter: '-' !default;
 
-$defaultQuery: $viewport-xs !default;
+$default-query: $viewport-xs !default;
 $sizes: $xs, $sm, $md, $lg !default;
 $queries: (
   $xs: $viewport-xs,

--- a/sass/_variables.scss
+++ b/sass/_variables.scss
@@ -31,7 +31,6 @@ $element-delimiter: '-' !default;
 $modifier-delimiter: '-' !default;
 
 $default-query: $viewport-xs !default;
-$sizes: $xs, $sm, $md, $lg !default;
 $queries: (
   $xs: $viewport-xs,
   $sm: $viewport-sm,

--- a/sass/flexboxgrid.scss
+++ b/sass/flexboxgrid.scss
@@ -9,12 +9,16 @@
   @include row();
 }
 
-@include columns() {
+%column {
   @include column();
 }
 
+@include columns() {
+  @extend %column;
+}
+
 @include offsets() {
-  @include column();
+  @extend %column;
 }
 
 @include breakpoints('.start') {

--- a/sass/flexboxgrid.scss
+++ b/sass/flexboxgrid.scss
@@ -1,168 +1,20 @@
-$column-count: 12 !default;
-$column-selector: '.col' !default;
-$offset-modifier: 'offset' !default;
-
-$gutter-width: 1rem !default;
-$outer-margin: 2rem !default;
-$gutter-compensation: (($gutter-width / 2) * -1) !default;
-$half-gutter-width: ($gutter-width / 2) !default;
-
-$width-xs: 30 !default;
-$width-sm: 48 !default;
-$width-md: 62 !default;
-$width-lg: 75 !default;
-
-$viewport-xs: $width-xs * 1em !default;
-$viewport-sm: $width-sm * 1em !default;
-$viewport-md: $width-md * 1em !default;
-$viewport-lg: $width-lg * 1em !default;
-
-$container-sm: $width-sm * 1rem + $gutter-width !default;
-$container-md: $width-md * 1rem + $gutter-width !default;
-$container-lg: $width-lg * 1rem + $gutter-width !default;
-
-$xs: 'xs' !default;
-$sm: 'sm' !default;
-$md: 'md' !default;
-$lg: 'lg' !default;
-
-$block-delimiter: '-' !default;
-$element-delimiter: '-' !default;
-$modifier-delimiter: '-' !default;
-
-$default-query: $viewport-xs !default;
-$sizes: $xs, $sm, $md, $lg !default;
-$queries: (
-	$xs: $viewport-xs, 
-	$sm: $viewport-sm, 
-	$md: $viewport-md, 
-	$lg: $viewport-lg,
-) !default;
-
-$column-properties: 'flex-basis', 'max-width' !default;
-$offset-properties: 'margin-left' !default;
-
-@mixin autoWidth() {
-  flex-grow: 1;
-  flex-basis: 0;
-  max-width: 100%;
-}
-
-@mixin percentWidth($property, $columns, $count) {
-  #{$property}: ((100% / $columns) * $count);
-}
-
-@mixin percentOffset($property, $columns, $count) {
-  $single-column-width: ((100% / $columns) * 1);
-  #{$property}: $single-column-width * $count;
-}
-
-@mixin queries($key, $queries) {
-  $query: map-get($queries, $key);
-  @if ($query == $default-query) {
-    @content;
-  } @else {
-    @media screen and (min-width: $query) {
-      @content;
-    }
-  }
-}
-
-@mixin columns($selector: $column-selector, $properties: $column-properties, $columns: $column-count, $queries: $queries) {
-  @for $i from 0 through $columns {
-    @each $size in $sizes {
-      @if ($i == 0) {
-        #{$selector + $block-delimiter + $size} {
-          @content;
-        }
-      } @else {
-        #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
-          @content;
-        }
-      }
-    }
-  }
-  @each $size in $sizes {
-    @include queries($size, $queries) {
-      @for $i from 0 through $columns {
-        @if ($i == 0) {
-          #{$selector + $block-delimiter + $size} {
-            @include autoWidth();
-          }
-        } @else {
-          #{$selector + $block-delimiter + $size + $modifier-delimiter + $i} {
-            @each $prop in $properties {
-              @include percentWidth($prop, $columns, $i);
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-@mixin offsets($selector: $column-selector, $modifier-selector: $offset-modifier, $properties: $offset-properties, $columns: $column-count, $queries: $queries) {
-  @each $size in $sizes {
-    @for $i from 1 through $columns {
-      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
-        @content;
-      }
-    }
-  }
-  @each $size in $sizes {
-    @for $i from 1 through $columns {
-      #{$selector + $block-delimiter + $size + $modifier-delimiter + $modifier-selector + $modifier-delimiter + $i} {
-        @include queries($size, $queries) {
-          @each $prop in $properties {
-            @include percentOffset($prop, $columns, $i);
-          }
-        }
-      }
-    }
-  }
-}
-
-@mixin breakpoints($selector, $queries: $queries) {
-  @each $size in $sizes {
-    #{$selector + $modifier-delimiter + $size} {
-      @include queries($size, $queries) {
-        @content;
-      }
-    }
-  }
-}
+@import 'variables';
+@import 'mixins';
 
 .container-fluid {
-  box-sizing: border-box;
-  margin-right: auto;
-  margin-left: auto;
-  padding-right: $outer-margin;
-  padding-left: $outer-margin;
+  @include container-fluid();
 }
 
 .row {
-  box-sizing: border-box;
-  display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
-  margin-right: $gutter-compensation;
-  margin-left: $gutter-compensation;
-}
-
-%column {
-  box-sizing: border-box;
-  flex-grow: 0;
-  flex-shrink: 0;
-  padding-right: $half-gutter-width;
-  padding-left: $half-gutter-width;
+  @include row();
 }
 
 @include columns() {
-  @extend %column;
+  @include column();
 }
 
 @include offsets() {
-  @extend %column;
+  @include column();
 }
 
 @include breakpoints('.start') {


### PR DESCRIPTION
Hey there!

We wanted to use flexboxgrid's sass on [Wizbii](https://wizbii.com) but the fact that the generated styles are included with the mixins makes it impossible as we already have components named row, col-xs, col-xs-1, and so on. This PR decouples the generated styles from the mixins so it's up to the implementor to chose how to handle that. The flexboxgrid file remains for those who just want the default stylings and namings without further configuration.