### PR TITLE
Update flexboxgrid.css

### DIFF
--- a/src/css/flexboxgrid.css
+++ b/src/css/flexboxgrid.css
@@ -80,6 +80,11 @@
   padding-left: var(--half-gutter-width, 0.5rem);
 }
 
+[class*="col-"] {
+  flex-basis: 100%;
+  max-width: 100%;
+}
+
 .col-xs {
   flex-grow: 1;
   flex-basis: 0;


### PR DESCRIPTION
Added fallback to col-* so any column behaves per default as col-xs-12 (mobile first) if no column number is specified for a certain screen size