### PR TITLE
Fixed issue #227

### DIFF
--- a/dist/flexboxgrid.css
+++ b/dist/flexboxgrid.css
@@ -5,6 +5,7 @@
 }
 
 .container-fluid {
+  max-width: 100%;
   padding-right: 2rem;
   padding-left: 2rem;
 }


### PR DESCRIPTION

### Description
Fixed the .row overflow issue when using **.col-xs-*** class. This bug is caused because **div.row** element width is more than the body element.
...

### Check List
__instruction : terminal command__
- [ ] run the build script `grunt`
- [ ] open  `index.html` in a browser & resize to test visual issues
