### PR TITLE
Fix GItHub brand name typo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -60,7 +60,7 @@
                 </div>
                 <div class="row center-xs">
                   <a class="button invisible-xs visible-md" href="https://github.com/kristoferjoseph/flexboxgrid/archive/v6.3.1.zip">Download</a>
-                  <a class="button" href="https://github.com/kristoferjoseph/flexboxgrid">Github</a>
+                  <a class="button" href="https://github.com/kristoferjoseph/flexboxgrid">GitHub</a>
 
                 </div>
             </header>


### PR DESCRIPTION
### Description
Fix GitHub brand name typo

### Check List
__instruction : terminal command__
- [x] run the build script `grunt`
- [x] open  `index.html` in a browser & resize to test visual issues
