### PR TITLE
Breakpoints full width when nothing smaller set

### DIFF
--- a/src/css/flexboxgrid.css
+++ b/src/css/flexboxgrid.css
@@ -16,8 +16,11 @@
   --container-lg: calc(var(--lg-min) + var(--gutter-width));
 }
 
+@custom-media --xs-viewport-segment only screen and (max-width: 48em);
 @custom-media --sm-viewport only screen and (min-width: 48em);
+@custom-media --sm-viewport-segment only screen and (min-width: 48em) and (max-width: 64em);
 @custom-media --md-viewport only screen and (min-width: 64em);
+@custom-media --md-viewport-segment only screen and (min-width: 64em) and (max-width: 75em);
 @custom-media --lg-viewport only screen and (min-width: 75em);
 
 .container-fluid, .container {
@@ -48,32 +51,10 @@
   flex-direction: column-reverse;
 }
 
-.col-xs,
-.col-xs-1,
-.col-xs-2,
-.col-xs-3,
-.col-xs-4,
-.col-xs-5,
-.col-xs-6,
-.col-xs-7,
-.col-xs-8,
-.col-xs-9,
-.col-xs-10,
-.col-xs-11,
-.col-xs-12,
-.col-xs-offset-0,
-.col-xs-offset-1,
-.col-xs-offset-2,
-.col-xs-offset-3,
-.col-xs-offset-4,
-.col-xs-offset-5,
-.col-xs-offset-6,
-.col-xs-offset-7,
-.col-xs-offset-8,
-.col-xs-offset-9,
-.col-xs-offset-10,
-.col-xs-offset-11,
-.col-xs-offset-12 {
+[class*='col-xs'],
+[class*='col-sm'],
+[class*='col-md'],
+[class*='col-lg'] {
   box-sizing: border-box;
   flex: 0 0 auto;
   padding-right: var(--half-gutter-width, 0.5rem);
@@ -237,41 +218,18 @@
   order: 1;
 }
 
+@media (--xs-viewport-segment) {
+  [class*='col-sm']:not([class*='col-xs']),
+  [class*='col-md']:not([class*='col-xs']),
+  [class*='col-lg']:not([class*='col-xs']) {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+}
+
 @media (--sm-viewport) {
   .container {
     width: var(--container-sm, 46rem);
-  }
-
-  .col-sm,
-  .col-sm-1,
-  .col-sm-2,
-  .col-sm-3,
-  .col-sm-4,
-  .col-sm-5,
-  .col-sm-6,
-  .col-sm-7,
-  .col-sm-8,
-  .col-sm-9,
-  .col-sm-10,
-  .col-sm-11,
-  .col-sm-12,
-  .col-sm-offset-0,
-  .col-sm-offset-1,
-  .col-sm-offset-2,
-  .col-sm-offset-3,
-  .col-sm-offset-4,
-  .col-sm-offset-5,
-  .col-sm-offset-6,
-  .col-sm-offset-7,
-  .col-sm-offset-8,
-  .col-sm-offset-9,
-  .col-sm-offset-10,
-  .col-sm-offset-11,
-  .col-sm-offset-12 {
-    box-sizing: border-box;
-    flex: 0 0 auto;
-    padding-right: var(--half-gutter-width, 0.5rem);
-    padding-left: var(--half-gutter-width, 0.5rem);
   }
 
   .col-sm {
@@ -432,41 +390,17 @@
   }
 }
 
+@media (--sm-viewport-segment) {
+  [class*='col-md']:not([class*='col-sm']):not([class*='col-xs']),
+  [class*='col-lg']:not([class*='col-sm']):not([class*='col-xs']) {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+}
+
 @media (--md-viewport) {
   .container {
     width: var(--container-md, 61rem);
-  }
-
-  .col-md,
-  .col-md-1,
-  .col-md-2,
-  .col-md-3,
-  .col-md-4,
-  .col-md-5,
-  .col-md-6,
-  .col-md-7,
-  .col-md-8,
-  .col-md-9,
-  .col-md-10,
-  .col-md-11,
-  .col-md-12,
-  .col-md-offset-0,
-  .col-md-offset-1,
-  .col-md-offset-2,
-  .col-md-offset-3,
-  .col-md-offset-4,
-  .col-md-offset-5,
-  .col-md-offset-6,
-  .col-md-offset-7,
-  .col-md-offset-8,
-  .col-md-offset-9,
-  .col-md-offset-10,
-  .col-md-offset-11,
-  .col-md-offset-12 {
-    box-sizing: border-box;
-    flex: 0 0 auto;
-    padding-right: var(--half-gutter-width, 0.5rem);
-    padding-left: var(--half-gutter-width, 0.5rem);
   }
 
   .col-md {
@@ -627,41 +561,16 @@
   }
 }
 
+@media (--md-viewport-segment) {
+  [class*='col-lg']:not([class*='col-md']):not([class*='col-sm']):not([class*='col-xs']) {
+    flex-basis: 100%;
+    max-width: 100%;
+  }
+}
+
 @media (--lg-viewport) {
   .container {
     width: var(--container-lg, 71rem);
-  }
-
-  .col-lg,
-  .col-lg-1,
-  .col-lg-2,
-  .col-lg-3,
-  .col-lg-4,
-  .col-lg-5,
-  .col-lg-6,
-  .col-lg-7,
-  .col-lg-8,
-  .col-lg-9,
-  .col-lg-10,
-  .col-lg-11,
-  .col-lg-12,
-  .col-lg-offset-0,
-  .col-lg-offset-1,
-  .col-lg-offset-2,
-  .col-lg-offset-3,
-  .col-lg-offset-4,
-  .col-lg-offset-5,
-  .col-lg-offset-6,
-  .col-lg-offset-7,
-  .col-lg-offset-8,
-  .col-lg-offset-9,
-  .col-lg-offset-10,
-  .col-lg-offset-11,
-  .col-lg-offset-12 {
-    box-sizing: border-box;
-    flex: 0 0 auto;
-    padding-right: var(--half-gutter-width, 0.5rem);
-    padding-left: var(--half-gutter-width, 0.5rem);
   }
 
   .col-lg {


### PR DESCRIPTION
Make full width the `col-lg*`, `col-md*` & `col-sm*` with no smaller breakpoints set.

Example
```
<div class="col-sm-6"></div>
```
is equivalant to
```
<div class="col-xs-12 col-sm-6"></div>
```