### PR TITLE
Add `https` to CDN link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Install
 
 <code>CDNJS</code>
 ```html
-<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css" type="text/css" >
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flexboxgrid/6.3.1/flexboxgrid.min.css" type="text/css" >
 ```
 
 ### css


### PR DESCRIPTION
### Description
Add missing `https` protocol in CDN link.

...

### Check List
__instruction : terminal command__
- [ ] run the build script `grunt`
- [ ] open  `index.html` in a browser & resize to test visual issues
